### PR TITLE
【iOS】【1.0.1】update 1.0.1

### DIFF
--- a/iOS/Example/Podfile
+++ b/iOS/Example/Podfile
@@ -1,7 +1,7 @@
 use_frameworks!
 
 platform :ios, '12.0'
-
+source 'https://github.com/CocoaPods/Specs.git'
 
 # UI库
 def ui
@@ -12,9 +12,7 @@ end
 # 工具库
 def tool
   pod 'Alamofire'
-  pod 'TUICore/ImSDK_Scenario', '7.0.1212'
-  pod 'TUIRoomEngine', '1.0.0'
-  pod 'TXLiteAVSDK_TRTC', '10.8.12025'
+  pod 'TUIRoomEngine', '1.0.1'
 end
 
 # 本地依赖库

--- a/iOS/TUIBarrage/TUIBarrage.podspec
+++ b/iOS/TUIBarrage/TUIBarrage.podspec
@@ -39,7 +39,7 @@ TODO: Add long description of the pod here.
   
   
   #  依赖内部库
-  spec.dependency 'TUICore/ImSDK_Scenario'
+  spec.dependency 'TUICore'
   
   #  OC第三方库
   spec.dependency 'Masonry'

--- a/iOS/TUIBeauty/TUIBeauty.podspec
+++ b/iOS/TUIBeauty/TUIBeauty.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |spec|
 
   spec.dependency 'Masonry'
   spec.dependency 'SSZipArchive'
-  spec.dependency 'TUICore/ImSDK_Scenario'
+  spec.dependency 'TUICore'
   
   spec.requires_arc = true
   spec.static_framework = true

--- a/iOS/TUIRoomKit/Source/Model/EngineManager.swift
+++ b/iOS/TUIRoomKit/Source/Model/EngineManager.swift
@@ -63,7 +63,7 @@ class EngineManager: NSObject {
     }
 
     class func setup(sdkAppId: Int, userId: String, userSig: String) {
-        TUIRoomEngine.setup(sdkAppId: sdkAppId, userId: userId, userSig: userSig) {
+        TUIRoomEngine.login(sdkAppId: sdkAppId, userId: userId, userSig: userSig) {
         } onError: { code, message in
             debugPrint("setup,code:\(code),message:\(message)")
         }

--- a/iOS/TUIRoomKit/TUIRoomKit.podspec
+++ b/iOS/TUIRoomKit/TUIRoomKit.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |spec|
   spec.dependency 'SnapKit'
   spec.dependency 'Kingfisher'
   spec.dependency 'TXAppBasic'
-  spec.dependency 'TUICore/ImSDK_Scenario'
+  spec.dependency 'TUICore'
   
   spec.default_subspec = 'TRTC'
   

--- a/iOS/TUIVideoSeat/TUIVideoSeat.podspec
+++ b/iOS/TUIVideoSeat/TUIVideoSeat.podspec
@@ -25,7 +25,7 @@ Pod::Spec.new do |spec|
   
   spec.dependency 'SnapKit'
   spec.dependency 'Kingfisher'
-  spec.dependency 'TUICore/ImSDK_Scenario'
+  spec.dependency 'TUICore'
   
   spec.default_subspec = 'TRTC'
   


### PR DESCRIPTION
- 修复登录/登出，进退房边界情况引发的房间状态问题
- 优化直播场景麦控逻辑，修复进退房，踢人出房间等边界条件问题
- 修复直播场景锁麦，静音麦位失败问题
- 修复直播场景管理员角色异常导致权限问题
- 修复部分稳定性问题