### PR TITLE
【Android】Fix the problem that the chat input box does not display text in dark mode

### DIFF
--- a/Android/tuichat/src/main/res/layout/chat_input_layout.xml
+++ b/Android/tuichat/src/main/res/layout/chat_input_layout.xml
@@ -42,6 +42,7 @@
             android:layout_weight="1"
             android:background="@drawable/msg_editor_border"
             android:textSize="@dimen/chat_input_text_size"
+            android:textColor="@color/black"
             android:maxHeight="120dp"
             android:minHeight="@dimen/chat_input_editor_height"
             android:textCursorDrawable="@drawable/my_cursor"


### PR DESCRIPTION
【Android】Fix the problem that the chat input box does not display text in dark mode