### PR TITLE
【Android】Gradle dependencies use wildcards to ensure that minor versions are automatically upgraded to the latest

### DIFF
--- a/Android/build.gradle
+++ b/Android/build.gradle
@@ -34,7 +34,7 @@ task clean(type: Delete) {
 }
 
 ext {
-    liteavSdk = "com.tencent.liteav:LiteAVSDK_TRTC:11.7.0.13946"
-    roomEngineSdk = "com.tencent.liteav.tuikit:tuiroomengine:2.2.1.26"
+    liteavSdk = "com.tencent.liteav:LiteAVSDK_TRTC:11.7.0.+"
+    roomEngineSdk = "com.tencent.liteav.tuikit:tuiroomengine:2.2.+"
     imSdk = "com.tencent.imsdk:imsdk-plus:7.8.5484"
 }

--- a/Android/tuiroomkit/build.gradle
+++ b/Android/tuiroomkit/build.gradle
@@ -50,8 +50,8 @@ dependencies {
 
     implementation project(':timcommon')
 
-    api rootProject.getProperties().containsKey("roomEngineSdk") ? rootProject.ext.roomEngineSdk : "com.tencent.liteav.tuikit:tuiroomengine:2.2.1.26"
-    implementation rootProject.getProperties().containsKey("liteavSdk") ? rootProject.ext.liteavSdk : "com.tencent.liteav:LiteAVSDK_TRTC:11.7.0.13946"
+    api rootProject.getProperties().containsKey("roomEngineSdk") ? rootProject.ext.roomEngineSdk : "com.tencent.liteav.tuikit:tuiroomengine:2.2.+"
+    implementation rootProject.getProperties().containsKey("liteavSdk") ? rootProject.ext.liteavSdk : "com.tencent.liteav:LiteAVSDK_TRTC:11.7.0.+"
     if (projects.contains("tuicore")) {
         api project(':tuicore')
     } else {


### PR DESCRIPTION
【Android】Gradle dependencies use wildcards to ensure that minor versions are automatically upgraded to the latest